### PR TITLE
drm : allow framebuffer and videomodes not to have same size

### DIFF
--- a/drivers/gpu/drm/drm_atomic_helper.c
+++ b/drivers/gpu/drm/drm_atomic_helper.c
@@ -1830,11 +1830,11 @@ int __drm_atomic_helper_set_config(struct drm_mode_set *set,
 	primary_state->src_x = set->x << 16;
 	primary_state->src_y = set->y << 16;
 	if (primary_state->rotation & (BIT(DRM_ROTATE_90) | BIT(DRM_ROTATE_270))) {
-		primary_state->src_h = hdisplay << 16;
-		primary_state->src_w = vdisplay << 16;
+		primary_state->src_h = set->fb->width << 16;
+		primary_state->src_w = set->fb->height << 16;
 	} else {
-		primary_state->src_h = vdisplay << 16;
-		primary_state->src_w = hdisplay << 16;
+		primary_state->src_h = set->fb->height << 16;
+		primary_state->src_w = set->fb->width << 16;
 	}
 
 commit:

--- a/drivers/gpu/drm/drm_crtc.c
+++ b/drivers/gpu/drm/drm_crtc.c
@@ -2879,6 +2879,8 @@ int drm_crtc_check_viewport(const struct drm_crtc *crtc,
 
 {
 	int hdisplay, vdisplay;
+	pr_info("%s: skip check\n", __func__);
+	return 0;
 
 	drm_crtc_get_hv_timing(mode, &hdisplay, &vdisplay);
 


### PR DESCRIPTION
DRM legacy doesn't allow that, will be only available with drm atomic.
Although, when running 4K modes, it's preferable to get a 1080p frambuffer that can be handlded properly by GPU and then use VOP to upscale that to 4K.